### PR TITLE
Added function to create `GroupMe::User` from a json

### DIFF
--- a/include/Message.h
+++ b/include/Message.h
@@ -103,6 +103,8 @@ namespace GroupMe {
              *
              * @param users The users that are the group that the message was sent in
              *
+             * @return Message a new message
+             *
              */
             static Message createFromJson(const nlohmann::json &json, const GroupMe::UserSet &user);
 

--- a/include/User.h
+++ b/include/User.h
@@ -22,6 +22,7 @@
 #include <cstdlib>
 #include <string>
 #include <memory>
+#include <nlohmann/json.hpp>
 
 namespace GroupMe {
     /**
@@ -60,6 +61,31 @@ namespace GroupMe {
              *
              */
             User();
+
+            /**
+             * @brief Constructs a `GroupMe::User` from a json
+             * 
+             * @param json The json that the user is represented by
+             * The json must have **_at least_** a `user_id`, but can have more.
+             * If an option is not specified it will be defaulted.
+             *
+             * A user json can look similar to:
+             * ```
+             * {
+             *      "id": "2000",
+             *      "user_id": "20000",
+             *      "nickname": "Anne",
+             *      "muted": false,
+             *      "image_url": "https://i.groupme.com/AVATAR",
+             *      "autokicked": false,
+             *      "app_installed": true,
+             *      "guid": "GUID-2"
+             * }
+             * ```
+             *
+             * @return User a new user
+             */
+            static User createFromJson(const nlohmann::json &json);
 
             /**
              * @brief Gets the users ID

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -46,6 +46,17 @@ User::User() :
 
 }
 
+User User::createFromJson(const nlohmann::json &json) {
+    User user;
+
+    user.setID(json.at("user_id"));
+    user.setNickname(json.value("nickname", ""));
+    user.setProfileImageURL(json.value("image_url", ""));
+    user.setGUID(json.value("guid", ""));
+
+    return user;
+}
+
 std::string User::getID() const {
     return m_userID;
 }


### PR DESCRIPTION
Seemed to simple to be true, but, alas, the functionality is here.

As with the `GroupMe::Message::createFromJson()` function you pass in a json and it will construct a user, though for this all that is required is a "user_id" element in the json, and everything else is optional, and will be defaulted to "" if it is not set. It is **_HIGHLY_** reccomended that you pass in those other options if possible. Although some of the4 options can not be applied to the user object, like "is_muted".